### PR TITLE
Fix Error:Deserialize JsonSerializationException

### DIFF
--- a/Bitget.Net/Objects/Models/BitgetSymbol.cs
+++ b/Bitget.Net/Objects/Models/BitgetSymbol.cs
@@ -97,6 +97,6 @@ namespace Bitget.Net.Objects.Models
         /// Max number of orders
         /// </summary>
         [JsonProperty("maxOrderNum")]
-        public int MaxOrders { get; set; }
+        public int? MaxOrders { get; set; }
     }
 }


### PR DESCRIPTION
When i use SpotApi.ExchangeData.GetSymbolsAsync，I get json deserialize error : Error converting value {null} to type 'System.Int32'. Path 'data[0].maxOrderNum', line 1, position 410., data: [Data only available in Trace LogLevel]
int MaxOrders property need change to int? MaxOrders