### PR TITLE
Add missing Trigger Order Plan Type for Partials

### DIFF
--- a/Bitget.Net/Enums/V2/TriggerOrderPlanType.cs
+++ b/Bitget.Net/Enums/V2/TriggerOrderPlanType.cs
@@ -29,6 +29,16 @@ namespace Bitget.Net.Enums.V2
         /// Position loss
         /// </summary>
         [Map("pos_loss")]
-        PosLoss
+        PosLoss,
+        /// <summary>
+        /// Partial profit
+        /// </summary>
+        [Map("profit_plan")]
+        PartialProfit,
+        /// <summary>
+        /// Partial loss
+        /// </summary>
+        [Map("loss_plan")]
+        PartialLoss
     }
 }


### PR DESCRIPTION
`TriggerOrderPlanType` is missing entries for Partial TP/SLs.

Example response:

```json
{
    "code": "00000",
    "msg": "success",
    "requestTime": 1740398082790,
    "data": {
        "entrustedList": [
            {
                "planType": "loss_plan",
                "symbol": "OPUSDT",
                ...
            },
            {
                "planType": "profit_plan",
                "symbol": "OPUSDT",
                ...
            }
        ]
    }
}
```