### PR TITLE
Added PreviousSequence to BitgetOrderBookUpdate

### DIFF
--- a/Bitget.Net/Objects/Models/V2/BitgetOrderBookUpdate.cs
+++ b/Bitget.Net/Objects/Models/V2/BitgetOrderBookUpdate.cs
@@ -34,5 +34,10 @@ namespace Bitget.Net.Objects.Models.V2
         /// </summary>
         [JsonPropertyName("seq")]
         public long? Sequence { get; set; }
+        /// <summary>
+        /// ["<c>pseq</c>"] Previous sequence number
+        /// </summary>
+        [JsonPropertyName("pseq")]
+        public long? PreviousSequence { get; set; }
     }
 }


### PR DESCRIPTION
I just found a new property in the raw OrderBookUpdate json response: `pseq` which seems to be the previous sequence number.
There was no checksum field returned in my test. So this might be deprecated. But I let this property as it is.
I couldn't find anything about either of those points in the official changelog