### PR TITLE
Fix cursor property type decimal -> string?

### DIFF
--- a/Bitget.Net/Objects/Models/Uta/BitgetUaFinancialRecordPage.cs
+++ b/Bitget.Net/Objects/Models/Uta/BitgetUaFinancialRecordPage.cs
@@ -18,7 +18,7 @@ public record BitgetUaFinancialRecordPage
     /// ["<c>cursor</c>"] Cursor
     /// </summary>
     [JsonPropertyName("cursor")]
-    public decimal Cursor { get; set; }
+    public string? Cursor { get; set; }
 }
 
 /// <summary>

--- a/Bitget.Net/Objects/Models/Uta/BitgetUaUserTrades.cs
+++ b/Bitget.Net/Objects/Models/Uta/BitgetUaUserTrades.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Text.Json.Serialization;
-using Bitget.Net.Enums;
+﻿using System.Text.Json.Serialization;
 using Bitget.Net.Enums.Uta;
 using Bitget.Net.Enums.V2;
 
@@ -20,7 +18,7 @@ public record BitgetUaUserTrades
     /// ["<c>cursor</c>"] Cursor
     /// </summary>
     [JsonPropertyName("cursor")]
-    public decimal Cursor { get; set; }
+    public string? Cursor { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
The BitgetUaUserTrades and BitgetUaFinancialRecordPage classes define a Cursor property of type decimal.

However, the corresponding Bitget API endpoints return the Cursor value as a string. As a result, the library fails to correctly deserialize and map the API response to these classes, causing the Cursor property to remain unset or triggering a deserialization error.
