### PR TITLE
Shared asset types

### DIFF
--- a/Bitget.Net/Bitget.Net.csproj
+++ b/Bitget.Net/Bitget.Net.csproj
@@ -56,10 +56,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Bitget.Net/Bitget.Net.csproj
+++ b/Bitget.Net/Bitget.Net.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -56,12 +56,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApi.cs
+++ b/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApi.cs
@@ -32,11 +32,15 @@ namespace Bitget.Net.Clients.FuturesApiV2
         /// <inheritdoc />
         public string ExchangeName => "Bitget";
 
+        internal BitgetRestClient _baseClient;
+
         protected override IRestMessageHandler MessageHandler { get; } = new BitgetRestMessageHandler(BitgetErrors.RestErrors);
 
         internal BitgetRestClientFuturesApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, BitgetRestClient baseClient, BitgetRestOptions options)
             : base(loggerFactory, BitgetExchange.Metadata.Id, httpClient, options.Environment.RestBaseAddress, options, options.FuturesOptions)
         {
+            _baseClient = baseClient;
+
             Account = new BitgetRestClientFuturesApiAccount(this);
             ExchangeData = new BitgetRestClientFuturesApiExchangeData(this);
             Trading = new BitgetRestClientFuturesApiTrading(this);

--- a/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApiShared.cs
+++ b/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApiShared.cs
@@ -1,6 +1,8 @@
 using Bitget.Net.Enums;
+using Bitget.Net.Enums.Uta;
 using Bitget.Net.Enums.V2;
 using Bitget.Net.Interfaces.Clients.FuturesApiV2;
+using Bitget.Net.Objects.Models;
 using Bitget.Net.Objects.Models.V2;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Interfaces;
@@ -172,6 +174,7 @@ namespace Bitget.Net.Clients.FuturesApiV2
 
         #region Futures Symbol client
 
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false)
         {
             RequiredExchangeParameters = new List<ParameterDescription>
@@ -185,68 +188,71 @@ namespace Bitget.Net.Clients.FuturesApiV2
             if (validationError != null)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
-            var productType = GetProductType(request.TradingMode, request.ExchangeParameters);
-            var result = await ExchangeData.GetContractsAsync(
-                productType,
+            var productCategory = GetProductCategory(request.TradingMode, request.ExchangeParameters);
+            var result = await _baseClient.UnifiedApi.ExchangeData.GetFuturesSymbolsAsync(
+                productCategory,
                 ct: ct).ConfigureAwait(false);
             if (!result.Success)
                 return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
-            IEnumerable<BitgetContract> data = result.Data;
-            if (request.TradingMode != null)
-            {
-                data = data
-                    .Where(x => ((request.TradingMode == TradingMode.PerpetualInverse || request.TradingMode == TradingMode.PerpetualLinear) && x.ContractType == ContractType.Perpetual)
-                             || ((request.TradingMode == TradingMode.DeliveryLinear || request.TradingMode == TradingMode.DeliveryInverse) && x.ContractType == ContractType.Delivery));
-            }
+            var data = result.Data
+                .Select(x => ParseSymbol(x, productCategory))
+                .ToArray();
 
-            var resultData = data.Select(s => ParseSymbol(s, productType)).ToArray();
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
-
-            if (request.SymbolType != null)
-                resultData = resultData.Where(s => s.SymbolType == request.SymbolType).ToArray();
-            if (request.SymbolSubType != null)
-                resultData = resultData.Where(s => s.SymbolSubType == request.SymbolSubType).ToArray();
-
-            var response = HttpResult.Ok(result, resultData);
-            return response;
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, productCategory.ToString(), data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
         }
 
-        private SharedFuturesSymbol ParseSymbol(BitgetContract s, BitgetProductTypeV2 productType)
+        private SharedFuturesSymbol ParseSymbol(BitgetUaFuturesSymbol s, ProductCategory productCategory)
         {
-            var (symbolType, subType) = ParseSymbolType(s);
-            return new SharedFuturesSymbol(
-                    productType == BitgetProductTypeV2.CoinFutures && s.ContractType == ContractType.Delivery ? TradingMode.DeliveryInverse :
-                    productType == BitgetProductTypeV2.CoinFutures && s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualInverse :
+            var result = new SharedFuturesSymbol(
+                    productCategory == ProductCategory.CoinFutures && s.Type == ContractType.Delivery ? TradingMode.DeliveryInverse :
+                    productCategory == ProductCategory.CoinFutures && s.Type == ContractType.Perpetual ? TradingMode.PerpetualInverse :
                     s.DeliveryPeriod.HasValue ? TradingMode.DeliveryLinear :
                     TradingMode.PerpetualLinear,
                     s.BaseAsset,
                     s.QuoteAsset,
                     s.Symbol,
-                    s.Status == Enums.V2.FuturesSymbolStatus.Normal)
+                    s.Status == InstrumentStatus.Online)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
-                PriceDecimals = s.PriceDecimals,
-                QuantityDecimals = s.QuantityDecimals,
+                PriceDecimals = s.PricePrecision,
+                QuantityDecimals = s.QuantityPrecision,
                 DeliveryTime = s.DeliveryTime,
-                PriceStep = s.PriceStep,
-                QuantityStep = s.QuantityStep,
+                PriceStep = s.PriceMultiplier,
+                QuantityStep = s.QuantityMultiplier,
                 ContractSize = 1,
                 MaxShortLeverage = s.MaxLeverage,
                 MaxLongLeverage = s.MaxLeverage,
-                MaxTradeQuantity = s.MaxLimitOrderQuantity == null && s.MaxLimitOrderQuantity == null ? null : Math.Min(s.MaxLimitOrderQuantity ?? decimal.MaxValue, s.MaxMarketOrderQuantity ?? decimal.MaxValue),
+                MaxTradeQuantity = Math.Min(s.MaxOrderQuantity, s.MaxMarketOrderQuantity),
                 DisplayName = s.Symbol,
-                SymbolType = symbolType,
-                SymbolSubType = subType
             };
+
+            if (productCategory != ProductCategory.CoinFutures)
+            {
+                result.BaseAssetType = s.IsRwa ? SharedAssetType.TradFi : SharedAssetType.Crypto;
+                result.BaseAssetSubType = ParseSymbolSubType(s);
+                result.QuoteAssetType = SharedAssetType.Crypto;
+                result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+                result.QuoteAssetType = SharedAssetType.Fiat;
+            }
+
+            return result;
         }
 
-        private (SymbolAssetType, SymbolAssetSubType?) ParseSymbolType(BitgetContract s)
+        private SharedAssetSubType? ParseSymbolSubType(BitgetUaFuturesSymbol s)
         {
-            if (s.IsRwa)
-                return (SymbolAssetType.Rwa, null);
+            if (s.SymbolType == SymbolType.Commodity || s.SymbolType == SymbolType.Metal)
+                return SharedAssetSubType.Commodity;
 
-            return (SymbolAssetType.CryptoOrFiat, null);
+            if (s.SymbolType == SymbolType.Stock)
+                return SharedAssetSubType.Stock;
+
+            return null;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)
@@ -1513,11 +1519,18 @@ namespace Bitget.Net.Clients.FuturesApiV2
             return (BitgetProductTypeV2)Enum.Parse(typeof(BitgetProductTypeV2), productTypeStr!);
         }
 
-        public static DateTime RoundUp(DateTime dt, TimeSpan d)
+        private ProductCategory GetProductCategory(TradingMode? tradingMode, ExchangeParameters? exchangeParameters)
         {
-            var modTicks = dt.Ticks % d.Ticks;
-            var delta = modTicks != 0 ? d.Ticks - modTicks : 0;
-            return new DateTime(dt.Ticks + delta, dt.Kind);
+            var productType = GetProductType(tradingMode, exchangeParameters);
+            if (productType == BitgetProductTypeV2.CoinFutures)
+                return ProductCategory.CoinFutures;
+            else if(productType == BitgetProductTypeV2.UsdtFutures)
+                return ProductCategory.UsdtFutures;
+            else if (productType == BitgetProductTypeV2.UsdcFutures)
+                return ProductCategory.UsdcFutures;
+
+            throw new ArgumentException("ProductType", $"Invalid product type {productType} for futures");
         }
+
     }
 }

--- a/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApiShared.cs
+++ b/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApiShared.cs
@@ -174,7 +174,7 @@ namespace Bitget.Net.Clients.FuturesApiV2
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false)
         {
             RequiredExchangeParameters = new List<ParameterDescription>

--- a/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApiShared.cs
+++ b/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApiShared.cs
@@ -3,6 +3,7 @@ using Bitget.Net.Enums.V2;
 using Bitget.Net.Interfaces.Clients.FuturesApiV2;
 using Bitget.Net.Objects.Models.V2;
 using CryptoExchange.Net;
+using CryptoExchange.Net.Interfaces;
 using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Objects.Errors;
 using CryptoExchange.Net.SharedApis;
@@ -199,16 +200,30 @@ namespace Bitget.Net.Clients.FuturesApiV2
                              || ((request.TradingMode == TradingMode.DeliveryLinear || request.TradingMode == TradingMode.DeliveryInverse) && x.ContractType == ContractType.Delivery));
             }
 
-            var response = HttpResult.Ok(result, data.Select(s => 
-            new SharedFuturesSymbol(
-                productType == BitgetProductTypeV2.CoinFutures && s.ContractType == ContractType.Delivery ? TradingMode.DeliveryInverse :
-                productType == BitgetProductTypeV2.CoinFutures && s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualInverse :
-                s.DeliveryPeriod.HasValue ? TradingMode.DeliveryLinear :
-                TradingMode.PerpetualLinear,
-                s.BaseAsset,
-                s.QuoteAsset,
-                s.Symbol, 
-                s.Status == Enums.V2.FuturesSymbolStatus.Normal)
+            var resultData = data.Select(s => ParseSymbol(s, productType)).ToArray();
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData);
+
+            if (request.SymbolType != null)
+                resultData = resultData.Where(s => s.SymbolType == request.SymbolType).ToArray();
+            if (request.SymbolSubType != null)
+                resultData = resultData.Where(s => s.SymbolSubType == request.SymbolSubType).ToArray();
+
+            var response = HttpResult.Ok(result, resultData);
+            return response;
+        }
+
+        private SharedFuturesSymbol ParseSymbol(BitgetContract s, BitgetProductTypeV2 productType)
+        {
+            var (symbolType, subType) = ParseSymbolType(s);
+            return new SharedFuturesSymbol(
+                    productType == BitgetProductTypeV2.CoinFutures && s.ContractType == ContractType.Delivery ? TradingMode.DeliveryInverse :
+                    productType == BitgetProductTypeV2.CoinFutures && s.ContractType == ContractType.Perpetual ? TradingMode.PerpetualInverse :
+                    s.DeliveryPeriod.HasValue ? TradingMode.DeliveryLinear :
+                    TradingMode.PerpetualLinear,
+                    s.BaseAsset,
+                    s.QuoteAsset,
+                    s.Symbol,
+                    s.Status == Enums.V2.FuturesSymbolStatus.Normal)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 PriceDecimals = s.PriceDecimals,
@@ -219,11 +234,19 @@ namespace Bitget.Net.Clients.FuturesApiV2
                 ContractSize = 1,
                 MaxShortLeverage = s.MaxLeverage,
                 MaxLongLeverage = s.MaxLeverage,
-                MaxTradeQuantity = s.MaxLimitOrderQuantity == null && s.MaxLimitOrderQuantity == null ? null : Math.Min(s.MaxLimitOrderQuantity ?? decimal.MaxValue, s.MaxMarketOrderQuantity ?? decimal.MaxValue)
-            }).ToArray());
+                MaxTradeQuantity = s.MaxLimitOrderQuantity == null && s.MaxLimitOrderQuantity == null ? null : Math.Min(s.MaxLimitOrderQuantity ?? decimal.MaxValue, s.MaxMarketOrderQuantity ?? decimal.MaxValue),
+                DisplayName = s.Symbol,
+                SymbolType = symbolType,
+                SymbolSubType = subType
+            };
+        }
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
-            return response;
+        private (SymbolAssetType, SymbolAssetSubType?) ParseSymbolType(BitgetContract s)
+        {
+            if (s.IsRwa)
+                return (SymbolAssetType.Rwa, null);
+
+            return (SymbolAssetType.CryptoOrFiat, null);
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApiShared.cs
+++ b/Bitget.Net/Clients/FuturesApiV2/BitgetRestClientFuturesApiShared.cs
@@ -250,7 +250,7 @@ namespace Bitget.Net.Clients.FuturesApiV2
                 return SharedAssetSubType.Commodity;
 
             if (s.SymbolType == SymbolType.Stock)
-                return SharedAssetSubType.Stock;
+                return SharedAssetSubType.Equity;
 
             return null;
         }

--- a/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApi.cs
+++ b/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApi.cs
@@ -38,9 +38,13 @@ namespace Bitget.Net.Clients.SpotApiV2
 
         protected override IRestMessageHandler MessageHandler { get; } = new BitgetRestMessageHandler(BitgetErrors.RestErrors);
 
+        internal BitgetRestClient _baseClient;
+
         internal BitgetRestClientSpotApi(ILoggerFactory? loggerFactory, HttpClient? httpClient, BitgetRestClient baseClient, BitgetRestOptions options)
             : base(loggerFactory, BitgetExchange.Metadata.Id, httpClient, options.Environment.RestBaseAddress, options, options.SpotOptions)
         {
+            _baseClient = baseClient;
+
             Account = new BitgetRestClientSpotApiAccount(this);
             Margin = new BitgetRestClientSpotApiMargin(this);
             ExchangeData = new BitgetRestClientSpotApiExchangeData(this);

--- a/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
+++ b/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
@@ -85,7 +85,7 @@ namespace Bitget.Net.Clients.SpotApiV2
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)

--- a/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
+++ b/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
@@ -1,6 +1,7 @@
 using Bitget.Net.Enums;
 using Bitget.Net.Enums.V2;
 using Bitget.Net.Interfaces.Clients.SpotApiV2;
+using Bitget.Net.Objects.Models;
 using Bitget.Net.Objects.Models.V2;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Objects;
@@ -18,6 +19,7 @@ namespace Bitget.Net.Clients.SpotApiV2
         public void SetDefaultExchangeParameter(string key, object value) => ExchangeParameters.SetStaticParameter(Exchange, key, value);
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(BitgetExchange.Metadata, this);
+        private static HashSet<string> _exchangeSupportedFiatCurrencies = ["EUR", "USD", "BRL"];
 
         #region Kline client
 
@@ -83,6 +85,7 @@ namespace Bitget.Net.Clients.SpotApiV2
         #endregion
 
         #region Spot Symbol client
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -91,43 +94,66 @@ namespace Bitget.Net.Clients.SpotApiV2
             if (validationError != null)
                 return HttpResult.Fail<SharedSpotSymbol[]>(Exchange, validationError);
 
-            var result = await ExchangeData.GetSymbolsAsync(ct: ct).ConfigureAwait(false);
+            var result = await _baseClient.UnifiedApi.ExchangeData.GetSpotSymbolsAsync(ct: ct).ConfigureAwait(false);
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var resultData = result.Data.Select(ParseSymbol);
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
+            var data = result.Data
+                .Select(x => ParseSymbol(x)!)
+                .Where(x => x != null)
+                .ToArray();
 
-            if (request.SymbolType != null)
-                resultData = resultData.Where(x => x.SymbolType == request.SymbolType);
-            if (request.SymbolSubType != null)
-                resultData = resultData.Where(x => x.SymbolSubType == request.SymbolSubType);
-
-            return HttpResult.Ok(result, resultData.ToArray());
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
         }
 
-        private SharedSpotSymbol ParseSymbol(BitgetSymbol s)
+        private SharedSpotSymbol ParseSymbol(BitgetUaSpotSymbol s)
         {
-            var (symbolType, symbolSubType) = ParseSymbolType(s);
-            return new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.Status == Enums.SymbolStatus.Online)
+            var result = new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.Status == Enums.Uta.InstrumentStatus.Online)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 MinNotionalValue = s.MinOrderValue,
                 MaxTradeQuantity = s.MaxOrderQuantity,
                 QuantityDecimals = s.QuantityPrecision,
                 PriceDecimals = s.PricePrecision,
-                SymbolType = symbolType,
-                SymbolSubType = symbolSubType,
                 DisplayName = s.Symbol
             };
-        }
 
-        private (SymbolAssetType, SymbolAssetSubType?) ParseSymbolType(BitgetSymbol s)
-        {
-            if (LibraryHelpers.IsStableCoin(s.BaseAsset))
-                return (SymbolAssetType.CryptoOrFiat, SymbolAssetSubType.StableCoin);
+            if (s.SymbolType == Enums.Uta.SymbolType.Commodity || s.SymbolType == Enums.Uta.SymbolType.Metal)
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Commodity;
+            }
+            else if (s.SymbolType == Enums.Uta.SymbolType.Stock)
+            {
+                result.BaseAssetType = SharedAssetType.TradFi;
+                result.BaseAssetSubType = SharedAssetSubType.Stock;
+            } 
+            else if (LibraryHelpers.IsStableCoin(s.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+                result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else if (_exchangeSupportedFiatCurrencies.Contains(s.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.Fiat;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+            }
 
-            return (SymbolAssetType.CryptoOrFiat, null);
+            if (LibraryHelpers.IsStableCoin(s.QuoteAsset))
+            {
+                result.QuoteAssetType = SharedAssetType.Crypto;
+                result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
+            }
+            else if (_exchangeSupportedFiatCurrencies.Contains(s.QuoteAsset))
+            {
+                result.QuoteAssetType = SharedAssetType.Fiat;
+            }
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
+++ b/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
@@ -95,17 +95,39 @@ namespace Bitget.Net.Clients.SpotApiV2
             if (!result.Success)
                 return HttpResult.Fail<SharedSpotSymbol[]>(result);
 
-            var response = HttpResult.Ok(result, result.Data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.Status == Enums.SymbolStatus.Online)
+            var resultData = result.Data.Select(ParseSymbol);
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, resultData.ToArray());
+
+            if (request.SymbolType != null)
+                resultData = resultData.Where(x => x.SymbolType == request.SymbolType);
+            if (request.SymbolSubType != null)
+                resultData = resultData.Where(x => x.SymbolSubType == request.SymbolSubType);
+
+            return HttpResult.Ok(result, resultData.ToArray());
+        }
+
+        private SharedSpotSymbol ParseSymbol(BitgetSymbol s)
+        {
+            var (symbolType, symbolSubType) = ParseSymbolType(s);
+            return new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.Status == Enums.SymbolStatus.Online)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 MinNotionalValue = s.MinOrderValue,
                 MaxTradeQuantity = s.MaxOrderQuantity,
                 QuantityDecimals = s.QuantityPrecision,
-                PriceDecimals = s.PricePrecision
-            }).ToArray());
+                PriceDecimals = s.PricePrecision,
+                SymbolType = symbolType,
+                SymbolSubType = symbolSubType,
+                DisplayName = s.Symbol
+            };
+        }
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicId, EnvironmentName, null, response.Data!);
-            return response;
+        private (SymbolAssetType, SymbolAssetSubType?) ParseSymbolType(BitgetSymbol s)
+        {
+            if (LibraryHelpers.IsStableCoin(s.BaseAsset))
+                return (SymbolAssetType.CryptoOrFiat, SymbolAssetSubType.StableCoin);
+
+            return (SymbolAssetType.CryptoOrFiat, null);
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)

--- a/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
+++ b/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
@@ -127,7 +127,7 @@ namespace Bitget.Net.Clients.SpotApiV2
             else if (s.SymbolType == Enums.Uta.SymbolType.Stock)
             {
                 result.BaseAssetType = SharedAssetType.TradFi;
-                result.BaseAssetSubType = SharedAssetSubType.Stock;
+                result.BaseAssetSubType = SharedAssetSubType.Equity;
             } 
             else if (LibraryHelpers.IsStableCoin(s.BaseAsset))
             {

--- a/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
+++ b/Bitget.Net/Clients/SpotApiV2/BitgetRestClientSpotApiShared.cs
@@ -152,6 +152,10 @@ namespace Bitget.Net.Clients.SpotApiV2
             {
                 result.QuoteAssetType = SharedAssetType.Fiat;
             }
+            else
+            {
+                result.QuoteAssetType = SharedAssetType.Crypto;
+            }
 
             return result;
         }


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models