### PR TITLE
Add GetClosedOrdersAsync for Unified (UTA) trading API

### DIFF
--- a/Bitget.Net.UnitTests/Bitget.Net.UnitTests.csproj
+++ b/Bitget.Net.UnitTests/Bitget.Net.UnitTests.csproj
@@ -6,7 +6,7 @@
 	  <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-	<ItemGroup>
+  <ItemGroup>
 		<packagereference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"></packagereference>
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<packagereference Include="NUnit" Version="4.4.0"></packagereference>

--- a/Bitget.Net.UnitTests/Endpoints/Unified/Trading/GetClosedOrders.txt
+++ b/Bitget.Net.UnitTests/Endpoints/Unified/Trading/GetClosedOrders.txt
@@ -1,0 +1,54 @@
+GET
+/api/v3/trade/history-orders
+true
+UriParams: {"category": "SPOT"}
+{
+  "code": "00000",
+  "msg": "success",
+  "requestTime": 1730186730084,
+  "data": {
+    "list": [
+      {
+        "orderId": "111111111111111111",
+        "clientOid": "111111111111111111",
+        "category": "USDT-FUTURES",
+        "symbol": "BTCUSDT",
+        "orderType": "limit",
+        "side": "sell",
+        "price": "49534.4",
+        "qty": "0.429",
+        "amount": "0",
+        "cumExecQty": "0.429",
+        "cumExecValue": "21250.2929",
+        "avgPrice": "49534.4",
+        "timeInForce": "gtc",
+        "orderStatus": "filled",
+        "posSide": "long",
+        "holdMode": "hedge_mode",
+        "delegateType": "normal",
+        "reduceOnly": "NO",
+        "marginMode": "crossed",
+        "stpMode": "none",
+        "takeProfit": "",
+        "stopLoss": "",
+        "tpTriggerBy": "",
+        "slTriggerBy": "",
+        "tpOrderType": "",
+        "slOrderType": "",
+        "tpLimitPrice": "",
+        "slLimitPrice": "",
+        "feeDetail": [
+          {
+            "feeCoin": "USDT",
+            "fee": "4.2500586"
+          }
+        ],
+        "cancelReason": "normal_cancel",
+        "execType": "liquidation",
+        "createdTime": "1730181468493",
+        "updatedTime": "1730181468493"
+      }
+    ],
+    "cursor": "1233319323918499840"
+  }
+}

--- a/Bitget.Net.UnitTests/RestRequestTests.cs
+++ b/Bitget.Net.UnitTests/RestRequestTests.cs
@@ -298,6 +298,7 @@ namespace Bitget.Net.UnitTests
             await tester.ValidateAsync(client => client.UnifiedApi.Trading.ClosePositionsAsync(ProductCategory.UsdtFutures), "ClosePositions", nestedJsonProperty: "data.list");
             await tester.ValidateAsync(client => client.UnifiedApi.Trading.GetOrderAsync(), "GetOrder", nestedJsonProperty: "data", ignoreProperties: ["reduceOnly"]);
             await tester.ValidateAsync(client => client.UnifiedApi.Trading.GetOpenOrdersAsync(), "GetOpenOrders", nestedJsonProperty: "data", ignoreProperties: ["reduceOnly"]);
+            await tester.ValidateAsync(client => client.UnifiedApi.Trading.GetClosedOrdersAsync(ProductCategory.Spot), "GetClosedOrders", nestedJsonProperty: "data");
             await tester.ValidateAsync(client => client.UnifiedApi.Trading.GetUserTradesAsync(), "GetUserTrades", nestedJsonProperty: "data", ignoreProperties: ["isRPI"]);
             await tester.ValidateAsync(client => client.UnifiedApi.Trading.GetPositionsAsync(ProductCategory.UsdtFutures), "GetPositions", nestedJsonProperty: "data.list");
             await tester.ValidateAsync(client => client.UnifiedApi.Trading.GetPositionHistoryAsync(ProductCategory.UsdtFutures), "GetPositionHistory", nestedJsonProperty: "data");

--- a/Bitget.Net/Clients/UnifiedApi/BitgetRestClientUnifiedApiTrading.cs
+++ b/Bitget.Net/Clients/UnifiedApi/BitgetRestClientUnifiedApiTrading.cs
@@ -205,6 +205,32 @@ namespace Bitget.Net.Clients.UnifiedApi
 
         #endregion
 
+        #region Get Closed Orders (history)
+
+        /// <inheritdoc />
+        public async Task<HttpResult<BitgetUaOrders>> GetClosedOrdersAsync(
+            ProductCategory category,
+            string? orderId = null,
+            DateTime? startTime = null,
+            DateTime? endTime = null,
+            int? limit = null,
+            string? cursor = null,
+            CancellationToken ct = default)
+        {
+            var parameters = new Parameters(BitgetExchange._parameterSerializationSettings);
+            parameters.Add("category", category);
+            parameters.Add("orderId", orderId);
+            parameters.Add("startTime", startTime);
+            parameters.Add("endTime", endTime);
+            parameters.Add("limit", limit);
+            parameters.Add("cursor", cursor);
+            var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, "/api/v3/trade/history-orders", BitgetExchange.RateLimiter.Overall, 1, true, limitGuard: new SingleLimitGuard(20, TimeSpan.FromSeconds(1), RateLimitWindowType.Sliding));
+            var result = await _baseClient.SendAsync<BitgetUaOrders>(request, parameters, ct).ConfigureAwait(false);
+            return result;
+        }
+
+        #endregion
+
         #region Get User Trades
 
         /// <inheritdoc />

--- a/Bitget.Net/Interfaces/Clients/UnifiedApi/IBitgetRestClientUnifiedApiTrading.cs
+++ b/Bitget.Net/Interfaces/Clients/UnifiedApi/IBitgetRestClientUnifiedApiTrading.cs
@@ -183,6 +183,31 @@ namespace Bitget.Net.Interfaces.Clients.UnifiedApi
             CancellationToken ct = default);
 
         /// <summary>
+        /// Get order history
+        /// <para>
+        /// Docs:<br />
+        /// <a href="https://www.bitget.com/api-doc/uta/trade/Get-Order-History" /><br />
+        /// Endpoint:<br />
+        /// GET /api/v3/trade/history-orders<br />
+        /// </para>
+        /// </summary>
+        /// <param name="category">["<c>category</c>"] Category</param>
+        /// <param name="symbol">["<c>symbol</c>"] Filter by symbol, for example `ETHUSDT`</param>
+        /// <param name="startTime">["<c>startTime</c>"] Filter by start time</param>
+        /// <param name="endTime">["<c>endTime</c>"] Filter by end time</param>
+        /// <param name="limit">["<c>limit</c>"] Max number of results, max 100</param>
+        /// <param name="cursor">["<c>cursor</c>"] Pagination cursor</param>
+        /// <param name="ct">Cancellation token</param>
+        Task<HttpResult<BitgetUaOrders>> GetClosedOrdersAsync(
+            ProductCategory category,
+            string? symbol = null,
+            DateTime? startTime = null,
+            DateTime? endTime = null,
+            int? limit = null,
+            string? cursor = null,
+            CancellationToken ct = default);
+
+        /// <summary>
         /// Get user trades
         /// <para>
         /// Docs:<br />


### PR DESCRIPTION
Adds support for the Bitget UTA order history endpoint (GET /api/v3/trade/history-orders) to the Unified API trading client, enabling retrieval of closed/historical orders across UTA product categories.

Changes
•	IBitgetRestClientUnifiedApiTrading: added new GetClosedOrdersAsync method with XML docs referencing the Bitget UTA Get Order History docs.
•	BitgetRestClientUnifiedApiTrading: implemented GetClosedOrdersAsync, wiring up parameters and returning HttpResult<BitgetUaOrders>.
•	Unit tests:
•	Added RestRequestTests entry for the new endpoint.
•	Added expected request fixture TestFiles/Endpoints/Unified/Trading/GetClosedOrders.txt.
•	Minor Bitget.Net.UnitTests.csproj adjustment.

Notes
•	No breaking changes; purely additive.
•	Follows the existing UTA trading method conventions (parameter naming, ProductCategory enum from Bitget.Net.Enums.Uta, HttpResult<T> return type).